### PR TITLE
Multitext

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,14 @@ set(LIBS
   freetype2
   )
 
+OPTION(DEV_PC
+  "Do not expect a frame buffer device, maybe do some tests."
+  OFF)
+
+IF(DEV_PC)
+  ADD_DEFINITIONS(-D_DEVELOPMENT_PC)
+ENDIF(DEV_PC)
+
 function(addLib name)
   pkg_check_modules(${name} REQUIRED ${name})
   include_directories(${${name}_INCLUDE_DIRS}) 

--- a/src/Command.h
+++ b/src/Command.h
@@ -4,13 +4,12 @@
 
 class Command
 {
-  public:
-    Command ();
-    virtual ~Command ();
+public:
+  Command();
+  virtual ~Command();
 
-    virtual int getNumArguments() const = 0;
-    virtual void execute(char **argv) = 0;
-    virtual std::string getHelp() const = 0;
-    virtual std::string getName() const = 0;
+  virtual int         getNumArguments() const           = 0;
+  virtual void        execute(char** argv, int numArgs) = 0;
+  virtual std::string getHelp() const                   = 0;
+  virtual std::string getName() const                   = 0;
 };
-

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -3,182 +3,344 @@
 #include <algorithm>
 #include <FrameBuffer.h>
 #include <Font.h>
+#include <regex>
+#include <tuple>
 
-extern char *selfPath;
+extern char* selfPath;
 
 namespace
 {
-  class ClearCommand : public Command
-  {
-    public:
-      virtual int getNumArguments () const override
-      {
-        return 0;
-      }
-
-      virtual void execute (char **argv) override
-      {
-        FrameBuffer::get ().clear ();
-      }
-
-      virtual std::string getHelp () const override
-      {
-        return "clear => entirely clears the framebuffer";
-      }
-
-      virtual std::string getName () const override
-      {
-        return "clear";
-      }
-  };
-
-  class TextCommand : public Command
-  {
-    public:
-      virtual int getNumArguments () const override
-      {
-        return 3;
-      }
-
-      virtual void execute (char **argv) override
-      {
-        auto app = Gio::File::create_for_path (selfPath);
-        auto parent = app->get_parent ();
-        auto parentPath = parent->get_path ();
-        auto resourcePath = parentPath + "/resources/";
-
-        Font f (resourcePath + "Emphase_8_Regular.ttf", 8);
-        FrameBuffer::get ().setColor (FrameBuffer::C255);
-        f.draw (argv[0], atoi (argv[1]), atoi (argv[2]));
-        g_usleep (10000);
-      }
-
-      virtual std::string getHelp () const override
-      {
-        return "'foo bar' x y => writes 'foo bar' at position x/y";
-      }
-
-      virtual std::string getName () const override
-      {
-        return "text";
-      }
-  };
-
-  class HorizontalLineCommand : public Command
-  {
-    public:
-      virtual int getNumArguments () const override
-      {
-        return 3;
-      }
-
-      virtual void execute (char **argv) override
-      {
-        FrameBuffer::get ().drawHorizontalLine (atoi (argv[0]), atoi (argv[1]), atoi (argv[2]));
-      }
-
-      virtual std::string getHelp () const override
-      {
-        return "x y l => draws a horizontal line of 'l' pixels length at x/y";
-      }
-
-      virtual std::string getName () const override
-      {
-        return "horizontal-line";
-      }
-  };
-
-  class VerticalLineCommand : public Command
-  {
-    public:
-      virtual int getNumArguments () const override
-      {
-        return 3;
-      }
-
-      virtual void execute (char **argv) override
-      {
-        FrameBuffer::get ().drawVerticalLine (atoi (argv[0]), atoi (argv[1]), atoi (argv[2]));
-      }
-
-      virtual std::string getHelp () const override
-      {
-        return "x y l => draws a vertical line of 'l' pixels length at x/y";
-      }
-
-      virtual std::string getName () const override
-      {
-        return "vertical-line";
-      }
-  };
-}
-
-Commands::Commands ()
+class ClearCommand : public Command
 {
-  m_commands.push_back (new ClearCommand ());
-  m_commands.push_back (new TextCommand ());
-  m_commands.push_back (new HorizontalLineCommand ());
-  m_commands.push_back (new VerticalLineCommand ());
+public:
+  virtual int getNumArguments() const override
+  {
+    return 0;
+  }
+
+  virtual void execute(char**, int) override
+  {
+    FrameBuffer::get().clear();
+  }
+
+  virtual std::string getHelp() const override
+  {
+    return "clear => entirely clears the framebuffer";
+  }
+
+  virtual std::string getName() const override
+  {
+    return "clear";
+  }
+};
+
+class TextCommand : public Command
+{
+public:
+  virtual int getNumArguments() const override
+  {
+    return 3;
+  }
+
+  virtual void execute(char** argv, int numArgs) override
+  {
+    if (numArgs > 2)
+    {
+      auto app          = Gio::File::create_for_path(selfPath);
+      auto parent       = app->get_parent();
+      auto parentPath   = parent->get_path();
+      auto resourcePath = parentPath + "/resources/";
+
+      Font f(resourcePath + "Emphase_8_Regular.ttf", 8);
+      FrameBuffer::get().setColor(FrameBuffer::C255);
+      f.draw(argv[0], atoi(argv[1]), atoi(argv[2]));
+    }
+  }
+
+  virtual std::string getHelp() const override
+  {
+    return "'foo bar' x y => writes 'foo bar' at position x/y";
+  }
+
+  virtual std::string getName() const override
+  {
+    return "text";
+  }
+};
+
+class HorizontalLineCommand : public Command
+{
+public:
+  virtual int getNumArguments() const override
+  {
+    return 3;
+  }
+
+  virtual void execute(char** argv, int numArgs) override
+  {
+    if (numArgs > 2)
+      FrameBuffer::get().drawHorizontalLine(atoi(argv[0]), atoi(argv[1]), atoi(argv[2]));
+  }
+
+  virtual std::string getHelp() const override
+  {
+    return "x y l => draws a horizontal line of 'l' pixels length at x/y";
+  }
+
+  virtual std::string getName() const override
+  {
+    return "horizontal-line";
+  }
+};
+
+class VerticalLineCommand : public Command
+{
+public:
+  virtual int getNumArguments() const override
+  {
+    return 3;
+  }
+
+  virtual void execute(char** argv, int numArgs) override
+  {
+    if (numArgs > 2)
+      FrameBuffer::get().drawVerticalLine(atoi(argv[0]), atoi(argv[1]), atoi(argv[2]));
+  }
+
+  virtual std::string getHelp() const override
+  {
+    return "x y l => draws a vertical line of 'l' pixels length at x/y";
+  }
+
+  virtual std::string getName() const override
+  {
+    return "vertical-line";
+  }
+};
+
+class MultiLineTextCommand : public Command
+{
+  enum class Alignment
+  {
+    Left,
+    Center,
+    Right
+  };
+
+  enum class Display
+  {
+    Boled,
+    Soled,
+  };
+
+  struct TextDef
+  {
+    Glib::ustring text;
+    Alignment     alignment;
+    Display       display;
+    int           line;
+  };
+
+  constexpr static int  lineHeight = 12;
+  std::unique_ptr<Font> font;
+
+public:
+  MultiLineTextCommand()
+  {
+    auto app          = Gio::File::create_for_path(selfPath);
+    auto parent       = app->get_parent();
+    auto parentPath   = parent->get_path();
+    auto resourcePath = parentPath + "/resources/";
+    font              = std::make_unique<Font>(resourcePath + "Emphase_8_Regular.ttf", 8);
+    FrameBuffer::get().setColor(FrameBuffer::C255);
+  }
+
+  virtual int getNumArguments() const override
+  {
+    return 3;
+  }
+
+  virtual void execute(char** argv, int numArgs) override
+  {
+    for (int i = 0; i < numArgs; i++)
+      draw(parsePart(argv[i]));
+  }
+
+  void draw(const TextDef& def)
+  {
+    if (def.display == Display::Boled)
+      drawOnBoled(def);
+    else
+      drawOnSoled(def);
+  }
+
+  void drawOnBoled(const TextDef& def)
+  {
+    int x = calcLeft(def.text, def.alignment, 256);
+    int y = lineHeight * (def.line + 1);
+    font->draw(def.text, x, y);
+  }
+
+  void drawOnSoled(const TextDef& def)
+  {
+    int x = calcLeft(def.text, def.alignment, 128);
+    int y = lineHeight * (def.line + 1) + 64;
+    font->draw(def.text, x, y);
+  }
+
+  int calcLeft(const Glib::ustring& text, Alignment align, int pixelsAvailable) const
+  {
+    if (align == Alignment::Left)
+      return 0;
+
+    auto width = static_cast<int>(font->getStringWidth(text));
+
+    if (align == Alignment::Right)
+      return std::max(0, pixelsAvailable - width);
+
+    auto diff = (pixelsAvailable - width) / 2;
+    return std::max(0, diff);
+  }
+
+  TextDef parsePart(const std::string& in)
+  {
+    std::regex  textAndFormatSplit("(.*)@(([s|b|[0-4]|l|c|r])*)$", std::regex_constants::icase);
+    std::smatch match;
+
+    if (std::regex_match(in, match, textAndFormatSplit))
+      if (match.size() >= 2)
+        return {match[1].str(), parseAlignment(match[2]), parseDisplay(match[2]), parseLine(match[2])};
+
+    return {in, Alignment::Center, Display::Soled, 1};
+  }
+
+  Alignment parseAlignment(const std::string& in)
+  {
+    std::regex  alignmentRegex(".*([l|c|r]).*", std::regex_constants::icase);
+    std::smatch match;
+
+    if (std::regex_match(in, match, alignmentRegex))
+    {
+      if (match.size() == 2)
+      {
+        auto alignemnt = match[1].str();
+        if (alignemnt == "L" || alignemnt == "l")
+          return Alignment::Left;
+        if (alignemnt == "R" || alignemnt == "r")
+          return Alignment::Right;
+      }
+    }
+    return Alignment::Center;
+  }
+
+  Display parseDisplay(const std::string& in)
+  {
+    std::regex  alignmentRegex(".*([b|s]).*", std::regex_constants::icase);
+    std::smatch match;
+
+    if (std::regex_match(in, match, alignmentRegex))
+    {
+      if (match.size() == 2)
+      {
+        auto display = match[1].str();
+        if (display == "B" || display == "b")
+          return Display::Boled;
+        if (display == "S" || display == "s")
+          return Display::Soled;
+      }
+    }
+    return Display::Soled;
+  }
+
+  int parseLine(const std::string& in)
+  {
+    std::regex  alignmentRegex(".*([0-4]).*", std::regex_constants::icase);
+    std::smatch match;
+
+    if (std::regex_match(in, match, alignmentRegex))
+      if (match.size() == 2)
+        return stoi(match[1].str());
+
+    return 1;
+  }
+
+  virtual std::string getHelp() const override
+  {
+    return "text2soled multitext \"Text1@[B|S][0|1|2|3|4][L|C|R]\" \"Text2@[B|S][0|1|2|3|4][L|C|R]\" ...";
+  }
+
+  virtual std::string getName() const override
+  {
+    return "multitext";
+  }
+};
 }
 
-Commands::~Commands ()
+Commands::Commands()
+{
+  m_commands.push_back(new ClearCommand());
+  m_commands.push_back(new TextCommand());
+  m_commands.push_back(new HorizontalLineCommand());
+  m_commands.push_back(new VerticalLineCommand());
+  m_commands.push_back(new MultiLineTextCommand());
+}
+
+Commands::~Commands()
 {
 }
 
-void Commands::executeCommand (Command* c, int numArgs, char** argv)
+void Commands::executeCommand(Command* c, int numArgs, char** argv)
 {
   numArgs--;
-  if (numArgs == c->getNumArguments ())
-    c->execute (argv + 1);
+  argv++;
+  if (numArgs >= c->getNumArguments())
+    c->execute(argv, numArgs);
   else
-    showHelp ();
+    showHelp();
 }
 
-void Commands::execute (int numArgs, char **argv)
+void Commands::execute(int numArgs, char** argv)
 {
   try
   {
     if (numArgs > 0)
     {
-      if (auto c = findCommand (*argv))
+      if (auto c = findCommand(*argv))
       {
-        executeCommand (c, numArgs, argv);
+        executeCommand(c, numArgs, argv);
       }
       else
       {
         ClearCommand clear;
-        clear.execute(nullptr);
+        clear.execute(nullptr, 0);
 
         TextCommand text;
-        text.execute(argv);
+        if (numArgs >= text.getNumArguments())
+          text.execute(argv, numArgs);
       }
     }
   }
   catch (...)
   {
-    showHelp ();
+    showHelp();
   }
 }
 
-Command *Commands::findCommand (const std::string &name) const
+Command* Commands::findCommand(const std::string& name) const
 {
-  auto c = std::find_if (m_commands.begin (), m_commands.end (), [&](Command *c)
-  {
-    return c->getName() == name;
-  });
+  auto c = std::find_if(m_commands.begin(), m_commands.end(), [&](Command* c) { return c->getName() == name; });
 
-  if(c != m_commands.end())
+  if (c != m_commands.end())
     return *c;
 
   return nullptr;
 }
 
-void Commands::showHelp ()
+void Commands::showHelp()
 {
   for (auto c : m_commands)
   {
-    std::cout << c->getName () << std::endl;
-    std::cout << '\t' << c->getHelp () << std::endl << std::endl;
+    std::cout << c->getName() << std::endl;
+    std::cout << '\t' << c->getHelp() << std::endl << std::endl;
   }
 }
-

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -153,6 +153,7 @@ public:
     auto resourcePath = parentPath + "/resources/";
     font              = std::make_unique<Font>(resourcePath + "Emphase_8_Regular.ttf", 8);
     FrameBuffer::get().setColor(FrameBuffer::C255);
+    FrameBuffer::get().clear();
   }
 
   virtual int getNumArguments() const override

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -158,7 +158,7 @@ public:
 
   virtual int getNumArguments() const override
   {
-    return 3;
+    return 1;
   }
 
   virtual void execute(char** argv, int numArgs) override
@@ -205,7 +205,7 @@ public:
 
   TextDef parsePart(const std::string& in)
   {
-    std::regex  textAndFormatSplit("(.*)@(([s|b|[0-4]|l|c|r])*)$", std::regex_constants::icase);
+    std::regex  textAndFormatSplit("(.*)@(([sb01234lcr])*)$", std::regex_constants::icase);
     std::smatch match;
 
     if (std::regex_match(in, match, textAndFormatSplit))
@@ -217,7 +217,7 @@ public:
 
   Alignment parseAlignment(const std::string& in)
   {
-    std::regex  alignmentRegex(".*([l|c|r]).*", std::regex_constants::icase);
+    std::regex  alignmentRegex(".*([lcr]).*", std::regex_constants::icase);
     std::smatch match;
 
     if (std::regex_match(in, match, alignmentRegex))
@@ -236,7 +236,7 @@ public:
 
   Display parseDisplay(const std::string& in)
   {
-    std::regex  alignmentRegex(".*([b|s]).*", std::regex_constants::icase);
+    std::regex  alignmentRegex(".*([bs]).*", std::regex_constants::icase);
     std::smatch match;
 
     if (std::regex_match(in, match, alignmentRegex))
@@ -255,7 +255,7 @@ public:
 
   int parseLine(const std::string& in)
   {
-    std::regex  alignmentRegex(".*([0-4]).*", std::regex_constants::icase);
+    std::regex  alignmentRegex(".*([01234]).*", std::regex_constants::icase);
     std::smatch match;
 
     if (std::regex_match(in, match, alignmentRegex))

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -141,7 +141,7 @@ class MultiLineTextCommand : public Command
     int           line;
   };
 
-  constexpr static int  lineHeight = 12;
+  constexpr static int  lineHeight = 10;
   std::unique_ptr<Font> font;
 
 public:
@@ -205,7 +205,7 @@ public:
 
   TextDef parsePart(const std::string& in)
   {
-    std::regex  textAndFormatSplit("(.*)@(([sb01234lcr])*)$", std::regex_constants::icase);
+    std::regex  textAndFormatSplit("(.*)@(([sb012345lcr])*)$", std::regex_constants::icase);
     std::smatch match;
 
     if (std::regex_match(in, match, textAndFormatSplit))
@@ -255,7 +255,7 @@ public:
 
   int parseLine(const std::string& in)
   {
-    std::regex  alignmentRegex(".*([01234]).*", std::regex_constants::icase);
+    std::regex  alignmentRegex(".*([012345]).*", std::regex_constants::icase);
     std::smatch match;
 
     if (std::regex_match(in, match, alignmentRegex))
@@ -267,7 +267,8 @@ public:
 
   virtual std::string getHelp() const override
   {
-    return "text2soled multitext \"Text1@[B|S][0|1|2|3|4][L|C|R]\" \"Text2@[B|S][0|1|2|3|4][L|C|R]\" ...";
+    return "text2soled multitext \"Text1@BL0\" \"Text2@SR1\" ... will draw Text1 on boled, left, Line 0 and Text2 on "
+           "soled, right, line 1 ";
   }
 
   virtual std::string getName() const override

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -6,132 +6,141 @@
 #include <string.h>
 #include <iostream>
 
-
-FrameBuffer::FrameBuffer ()
+FrameBuffer::FrameBuffer()
 {
-  openAndMap ();
+  openAndMap();
   setColor(FrameBuffer::C255);
 }
 
-void FrameBuffer::openAndMap ()
+void FrameBuffer::openAndMap()
 {
-  m_fd = open ("/dev/fb0", O_RDWR);
+#ifndef _DEVELOPMENT_PC
+  m_fd = open("/dev/fb0", O_RDWR);
 
   if (m_fd < 0)
     g_error("Could not open framebuffer device file");
 
-  if (ioctl (m_fd, FBIOGET_VSCREENINFO, &m_varInfo) == -1)
+  if (ioctl(m_fd, FBIOGET_VSCREENINFO, &m_varInfo) == -1)
     g_error("Could not get fb_var_screeninfo!");
 
   auto bytesPerPixel = m_varInfo.bits_per_pixel / 8;
-  m_buffersize = m_varInfo.xres * m_varInfo.yres * bytesPerPixel;
-  m_frontBuffer = reinterpret_cast<tPixel*> (mmap (0, m_buffersize, PROT_READ | PROT_WRITE, MAP_SHARED, m_fd, 0));
+  m_buffersize       = m_varInfo.xres * m_varInfo.yres * bytesPerPixel;
+  m_frontBuffer      = reinterpret_cast<tPixel*>(mmap(0, m_buffersize, PROT_READ | PROT_WRITE, MAP_SHARED, m_fd, 0));
 
   if (m_frontBuffer == MAP_FAILED)
     g_error("Could not memory map buffer");
+#endif
 }
 
-FrameBuffer::~FrameBuffer ()
+FrameBuffer::~FrameBuffer()
 {
-  unmapAndClose ();
+  unmapAndClose();
 }
 
-void FrameBuffer::setPixel (tCoordinate x, tCoordinate y)
+void FrameBuffer::setPixel(tCoordinate x, tCoordinate y)
 {
-  setOffsetPixel (x, y);
+  setOffsetPixel(x, y);
 }
 
-inline void FrameBuffer::setOffsetPixel (tCoordinate x, tCoordinate y)
+inline void FrameBuffer::setOffsetPixel(tCoordinate x, tCoordinate y)
 {
-  setRawPixel (x, y);
+  setRawPixel(x, y);
 }
 
-inline void FrameBuffer::setRawPixel (tCoordinate x, tCoordinate y)
+inline void FrameBuffer::setRawPixel(tCoordinate x, tCoordinate y)
 {
-  const long index = getIndex (x, y);
+#ifndef _DEVELOPMENT_PC
+  const long index = getIndex(x, y);
 
-  if(index >= 0 && index < m_buffersize)
+  if (index >= 0 && index < m_buffersize)
     m_frontBuffer[index] = m_currentColor;
+#endif
 }
 
-inline long FrameBuffer::getIndex (tCoordinate x, tCoordinate y) const
+inline long FrameBuffer::getIndex(tCoordinate x, tCoordinate y) const
 {
   return (x + y * m_varInfo.xres);
 }
 
-void FrameBuffer::unmapAndClose ()
+void FrameBuffer::unmapAndClose()
 {
-  if (munmap (m_frontBuffer, m_buffersize))
-    g_error ("Error while un-mapping buffer");
+#ifndef _DEVELOPMENT_PC
+  if (munmap(m_frontBuffer, m_buffersize))
+    g_error("Error while un-mapping buffer");
 
-  if (close (m_fd))
-    g_error ("Error while closing file handle: ");
+  if (close(m_fd))
+    g_error("Error while closing file handle: ");
+#endif
 }
 
-void FrameBuffer::clear ()
+void FrameBuffer::clear()
 {
-  memset (m_frontBuffer, 0, m_buffersize);
+#ifndef _DEVELOPMENT_PC
+  memset(m_frontBuffer, 0, m_buffersize);
+#endif;
 }
 
-void FrameBuffer::setColor (const Colors &c)
+void FrameBuffer::setColor(const Colors& c)
 {
   m_currentColor = c;
 }
 
-void FrameBuffer::fiddleColor (tPixel p)
+void FrameBuffer::fiddleColor(tPixel p)
 {
-  m_currentColor = (Colors) (p);
+  m_currentColor = (Colors)(p);
 }
 
-FrameBuffer::Colors FrameBuffer::getColor () const
+FrameBuffer::Colors FrameBuffer::getColor() const
 {
   return m_currentColor;
 }
 
-void FrameBuffer::fillRect (tCoordinate left, tCoordinate top, tCoordinate width, tCoordinate height)
+void FrameBuffer::fillRect(tCoordinate left, tCoordinate top, tCoordinate width, tCoordinate height)
 {
-  fillRect (Rect (left, top, width, height));
+  fillRect(Rect(left, top, width, height));
 }
 
-void FrameBuffer::fillRect (const Rect &rect)
+void FrameBuffer::fillRect(const Rect& rect)
 {
-  for (auto y = rect.getTop (); y <= rect.getBottom(); y++)
-    drawRawHorizontalLine (rect.getLeft(), y, rect.getWidth());
+  for (auto y = rect.getTop(); y <= rect.getBottom(); y++)
+    drawRawHorizontalLine(rect.getLeft(), y, rect.getWidth());
 }
 
-inline void FrameBuffer::drawRawHorizontalLine (tCoordinate x, tCoordinate y, tCoordinate length)
+inline void FrameBuffer::drawRawHorizontalLine(tCoordinate x, tCoordinate y, tCoordinate length)
 {
-  auto fromIdx = getIndex (x, y);
+#ifndef _DEVELOPMENT_PC
+  auto fromIdx = getIndex(x, y);
 
   auto data = m_frontBuffer + fromIdx;
 
   for (long i = 0; i < length; i++)
     data[i] = m_currentColor;
+#endif
 }
 
-void FrameBuffer::drawRect (tCoordinate x, tCoordinate y, tCoordinate width, tCoordinate height)
+void FrameBuffer::drawRect(tCoordinate x, tCoordinate y, tCoordinate width, tCoordinate height)
 {
-  drawRect (Rect (x, y, width, height));
+  drawRect(Rect(x, y, width, height));
 }
 
-void FrameBuffer::drawRect (const Rect &rect)
+void FrameBuffer::drawRect(const Rect& rect)
 {
-  if (!rect.isEmpty ())
+  if (!rect.isEmpty())
   {
-    drawHorizontalLine (rect.getLeft (), rect.getTop (), rect.getWidth ());
-    drawHorizontalLine (rect.getLeft (), rect.getBottom (), rect.getWidth ());
-    drawVerticalLine (rect.getLeft (), rect.getTop (), rect.getHeight ());
-    drawVerticalLine (rect.getRight (), rect.getTop (), rect.getHeight ());
+    drawHorizontalLine(rect.getLeft(), rect.getTop(), rect.getWidth());
+    drawHorizontalLine(rect.getLeft(), rect.getBottom(), rect.getWidth());
+    drawVerticalLine(rect.getLeft(), rect.getTop(), rect.getHeight());
+    drawVerticalLine(rect.getRight(), rect.getTop(), rect.getHeight());
   }
 }
 
-void FrameBuffer::drawHorizontalLine (tCoordinate x, tCoordinate y, tCoordinate length)
+void FrameBuffer::drawHorizontalLine(tCoordinate x, tCoordinate y, tCoordinate length)
 {
-  drawRawHorizontalLine (x, y, length);
+  drawRawHorizontalLine(x, y, length);
 }
 
-void FrameBuffer::drawVerticalLine (tCoordinate x, tCoordinate y, tCoordinate length)
+void FrameBuffer::drawVerticalLine(tCoordinate x, tCoordinate y, tCoordinate length)
 {
   for (auto i = y; i < y + length; i++)
-    setRawPixel (x, i);
+    setRawPixel(x, i);
 }

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -77,7 +77,7 @@ void FrameBuffer::clear()
 {
 #ifndef _DEVELOPMENT_PC
   memset(m_frontBuffer, 0, m_buffersize);
-#endif;
+#endif
 }
 
 void FrameBuffer::setColor(const Colors& c)

--- a/src/text2soled.cpp
+++ b/src/text2soled.cpp
@@ -2,17 +2,17 @@
 #include "FrameBuffer.h"
 #include "Commands.h"
 
-char *selfPath = nullptr;
+char* selfPath = nullptr;
 
-int main (int numArgs, char **argv)
+int main(int numArgs, char** argv)
 {
-  Gio::init ();
+  Gio::init();
 
   selfPath = argv[0];
 
   Commands commands;
 
-  if(numArgs > 1)
+  if (numArgs > 1)
   {
     commands.execute(numArgs - 1, argv + 1);
   }
@@ -20,14 +20,15 @@ int main (int numArgs, char **argv)
   {
     std::string line;
 
-    while(std::getline(std::cin, line))
+    while (std::getline(std::cin, line))
     {
-      auto args = g_strsplit((const gchar*)line.c_str(), (const gchar*)" ", -1);
+      auto args    = g_strsplit((const gchar*) line.c_str(), (const gchar*) " ", -1);
       auto argsLen = g_strv_length(args);
       commands.execute(argsLen, args);
       g_strfreev(args);
     }
   }
 
+  sync();
   return 0;
 }


### PR DESCRIPTION
This PR adds a new command "multitext". It accepts unlimited number of texts. Each text accepts some formatting properties. Use it like this:

text2soled multitext "Text One@formatspec" "Text Two@formatspec" "Text Three@formatspec"

where 'formatspec' is a concatenation of 
- "S" for Soled
- "B" for Boled
- "L" for left alignment
- "R" for right alignment
- "C" for centered alignment
- 0...5 for the according line of the display

example:

text2soled multiline "Boled-First-Left@b0l" "Soled-Third-Centered@s2c"


The order of characters in formatspec can be arbitrary.